### PR TITLE
CORDA-4010 Fixed database schema error when deploying nodes locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         projectCordapp {
             deploy = false
         }
+        runSchemaMigration = true
+
         cordapp project(':business-networks-contracts')
         cordapp project(':business-networks-workflows')
     }

--- a/business-networks-demo/build.gradle
+++ b/business-networks-demo/build.gradle
@@ -21,6 +21,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         projectCordapp {
             deploy = false
         }
+        runSchemaMigration = true
+
         cordapp project(':business-networks-contracts')
         cordapp project(':business-networks-workflows')
         cordapp project(':business-networks-demo:business-networks-demo-contracts')


### PR DESCRIPTION
## Description

This simple PR introduces fix to database schema error when deploying nodes by adding `runSchemaMigration = true` to Cordform tasks.

## Test Plan

Ensure error doesn't appear anymore.

Before:
![schema_version_error](https://user-images.githubusercontent.com/37048878/91325490-2c847400-e7bb-11ea-9434-03812b7c2738.png)

After:
<img width="1611" alt="Screenshot 2020-08-26 at 16 41 52" src="https://user-images.githubusercontent.com/37048878/91325411-0fe83c00-e7bb-11ea-9633-868e1f4fe37a.png">
