### PR TITLE
NOTICK GroupState participants KDocs addition

### DIFF
--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/states/GroupState.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/states/GroupState.kt
@@ -18,6 +18,8 @@ import java.time.Instant
  * @property issuer The [Party] issuer of this state.
  * @property issued Timestamp when the state has been issued.
  * @property modified Timestamp when the state has been modified last time.
+ * @property participants List of all members that are part of the group. Also preserves
+ * [net.corda.core.contracts.ContractState.participants] definition.
  */
 @BelongsToContract(GroupContract::class)
 data class GroupState(


### PR DESCRIPTION
## Description

Now `GroupState.participants` field's KDocs also reflect additional purpose of being collection that stores group members.