### PR TITLE
EG-4132 Adapted BNE to certificate renewal feature

### DIFF
--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/contracts/MembershipContract.kt
@@ -111,7 +111,6 @@ open class MembershipContract : Contract {
             }
             outputState?.apply {
                 "Output state's modified timestamp should be greater or equal to issued timestamp" using (issued <= modified)
-                "Required signers should be subset of all output state's participants" using (participants.map { it.owningKey }.containsAll(command.value.requiredSigners))
             }
             if (inputState != null && outputState != null) {
                 "Input and output state should have same Corda identity" using (inputState.identity.cordaIdentity == outputState.identity.cordaIdentity)

--- a/business-networks-contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
+++ b/business-networks-contracts/src/test/kotlin/net/corda/bn/contracts/MembershipContractTest.kt
@@ -80,12 +80,6 @@ class MembershipContractTest {
                 command(memberIdentity.owningKey, MembershipContract.Commands.Request(listOf(memberIdentity.owningKey)))
                 this `fails with` "Output state's modified timestamp should be greater or equal to issued timestamp"
             }
-            transaction {
-                val output = membershipState.run { copy(participants = listOf(memberIdentity)) }
-                output(MembershipContract.CONTRACT_NAME, output)
-                command(bnoIdentity.owningKey, MembershipContract.Commands.Request(listOf(bnoIdentity.owningKey)))
-                this `fails with` "Required signers should be subset of all output state's participants"
-            }
 
             val input = membershipState
             transaction {

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ActivateMembershipFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ActivateMembershipFlow.kt
@@ -42,7 +42,7 @@ class ActivateMembershipFlow(private val membershipId: UniqueIdentifier, private
 
         // fetch signers
         val authorisedMemberships = bnService.getMembersAuthorisedToModifyMembership(networkId).toSet()
-        val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }
+        val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }.updated().toPartyList()
 
         // building transaction
         val outputMembership = membership.state.data.copy(status = MembershipStatus.ACTIVE, modified = serviceHub.clock.instant())
@@ -54,7 +54,7 @@ class ActivateMembershipFlow(private val membershipId: UniqueIdentifier, private
         builder.verify(serviceHub)
 
         // collect signatures and finalise transaction
-        val observerSessions = (outputMembership.participants - ourIdentity).map { initiateFlow(it) }
+        val observerSessions = (outputMembership.participants.updated() - ourIdentity).map { initiateFlow(it) }
         val finalisedTransaction = collectSignaturesAndFinaliseTransaction(builder, observerSessions, signers)
 
         auditLogger.info("$ourIdentity successfully activated member with $membershipId membership ID")

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/BNService.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/BNService.kt
@@ -115,7 +115,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
                 .and(identityCriteria(party))
         val states = serviceHub.vaultService.queryBy<MembershipState>(criteria).states
         return states.maxBy { it.state.data.modified }?.apply {
-            check(ourIdentity in state.data.participants) { "Caller is not part of any Business Network Group that $party is part of" }
+            check(ourIdentity.name in state.data.participants.map { it.nameOrNull() }) { "Caller is not part of any Business Network Group that $party is part of" }
         }
     }
 
@@ -135,7 +135,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
         val states = serviceHub.vaultService.queryBy<MembershipState>(criteria).states
         return states.maxBy { it.state.data.modified }?.apply {
             check(isBusinessNetworkMember(state.data.networkId, ourIdentity)) { "Caller is not member of the Business Network with ${state.data.networkId} ID" }
-            check(ourIdentity in state.data.participants) { "Caller is not part of any Business Network Group that ${state.data.identity.cordaIdentity} is part of" }
+            check(ourIdentity.name in state.data.participants.map { it.nameOrNull() }) { "Caller is not part of any Business Network Group that ${state.data.identity.cordaIdentity} is part of" }
         }
     }
 
@@ -171,8 +171,8 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
         val criteria = QueryCriteria.VaultQueryCriteria(Vault.StateStatus.UNCONSUMED)
                 .and(membershipNetworkIdCriteria(networkId))
                 .and(statusCriteria(statuses.toList()))
-        return serviceHub.vaultService.queryBy<MembershipState>(criteria).states.filter {
-            ourIdentity in it.state.data.participants
+        return serviceHub.vaultService.queryBy<MembershipState>(criteria).states.filter { membership ->
+            ourIdentity.name in membership.state.data.participants.map { it.nameOrNull() }
         }
     }
 
@@ -202,7 +202,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
         val criteria = QueryCriteria.VaultQueryCriteria(Vault.StateStatus.ALL)
                 .and(linearIdCriteria(groupId))
         val state = serviceHub.vaultService.queryBy<GroupState>(criteria).states.map { it.state.data }.maxBy { it.modified }
-        return state != null && ourIdentity in state.participants
+        return state != null && ourIdentity.name in state.participants.map { it.name }
     }
 
     /**
@@ -221,7 +221,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
                 .and(groupNetworkIdCriteria(networkId))
                 .and(groupNameCriteria(groupName))
         val state = serviceHub.vaultService.queryBy<GroupState>(criteria).states.map { it.state.data }.maxBy { it.modified }
-        return state != null && ourIdentity in state.participants
+        return state != null && ourIdentity.name in state.participants.map { it.name }
     }
 
     /**
@@ -238,7 +238,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
                 .and(linearIdCriteria(groupId))
         val states = serviceHub.vaultService.queryBy<GroupState>(criteria).states
         return states.maxBy { it.state.data.modified }?.apply {
-            check(ourIdentity in state.data.participants) { "Caller is not part of the Business Network Group with $groupId ID" }
+            check(ourIdentity.name in state.data.participants.map { it.name }) { "Caller is not part of the Business Network Group with $groupId ID" }
         }
     }
 
@@ -261,7 +261,7 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
                 .and(groupNameCriteria(groupName))
         val states = serviceHub.vaultService.queryBy<GroupState>(criteria).states
         return states.maxBy { it.state.data.modified }?.apply {
-            check(ourIdentity in state.data.participants) { "Caller is not part of the Business Network Group with $groupName name" }
+            check(ourIdentity.name in state.data.participants.map { it.name }) { "Caller is not part of the Business Network Group with $groupName name" }
         }
     }
 
@@ -279,8 +279,8 @@ class BNService(private val serviceHub: AppServiceHub) : SingletonSerializeAsTok
 
         val criteria = QueryCriteria.VaultQueryCriteria(Vault.StateStatus.UNCONSUMED)
                 .and(groupNetworkIdCriteria(networkId))
-        return serviceHub.vaultService.queryBy<GroupState>(criteria).states.filter {
-            ourIdentity in it.state.data.participants
+        return serviceHub.vaultService.queryBy<GroupState>(criteria).states.filter { group ->
+            ourIdentity.name in group.state.data.participants.map { it.name }
         }
     }
 

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/CreateGroupFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/CreateGroupFlow.kt
@@ -71,7 +71,7 @@ class CreateGroupFlow(
 
             // fetch signers
             val authorisedMemberships = bnService.getMembersAuthorisedToModifyMembership(networkId)
-            val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }
+            val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }.updated().toPartyList()
 
             // building transaction
             val group = GroupState(
@@ -88,7 +88,7 @@ class CreateGroupFlow(
             builder.verify(serviceHub)
 
             // collect signatures and finalise transaction
-            val observers = additionalParticipantsIdentities - ourIdentity
+            val observers = additionalParticipantsIdentities.updated() - ourIdentity
             val observerSessions = observers.map { initiateFlow(it) }
             val finalisedTransaction = collectSignaturesAndFinaliseTransaction(builder, observerSessions, signers)
 

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/DeleteGroupFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/DeleteGroupFlow.kt
@@ -53,7 +53,7 @@ class DeleteGroupFlow(private val groupId: UniqueIdentifier, private val notary:
 
         // fetch signers
         val authorisedMemberships = bnService.getMembersAuthorisedToModifyMembership(networkId)
-        val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }
+        val signers = authorisedMemberships.filter { it.state.data.isActive() }.map { it.state.data.identity.cordaIdentity }.updated().toPartyList()
 
         // building group exit transaction since deleted group state must be marked historic on all participants's vaults.
         val requiredSigners = signers.map { it.owningKey }
@@ -63,7 +63,7 @@ class DeleteGroupFlow(private val groupId: UniqueIdentifier, private val notary:
         builder.verify(serviceHub)
 
         // collect signatures and finalise transaction
-        val observers = group.state.data.participants - ourIdentity
+        val observers = group.state.data.participants.updated() - ourIdentity
         val observerSessions = observers.map { initiateFlow(it) }
         val finalisedTransaction = collectSignaturesAndFinaliseTransaction(builder, observerSessions, signers)
 

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/MembershipManagementFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/MembershipManagementFlow.kt
@@ -13,6 +13,7 @@ import net.corda.core.flows.ReceiveFinalityFlow
 import net.corda.core.flows.ReceiveTransactionFlow
 import net.corda.core.flows.SendTransactionFlow
 import net.corda.core.flows.SignTransactionFlow
+import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.node.StatesToRecord
 import net.corda.core.transactions.SignedTransaction
@@ -173,4 +174,15 @@ abstract class MembershipManagementFlow<T> : FlowLogic<T>() {
             subFlow(ModifyParticipantsFlow(membership, newParticipants.toList(), signers, notary))
         }
     }
+
+    /** Returns list of [Party] objects with latest owning key. **/
+    protected fun Collection<AbstractParty>.updated(): List<AbstractParty> = map {
+        it.nameOrNull()?.let { name ->
+            serviceHub.identityService.wellKnownPartyFromX500Name(name)
+                    ?: throw FlowException("Party with $name X500 name doesn't exist")
+        } ?: it
+    }
+
+    /** Casts all [AbstractParty] objects of the collection to [Party]. **/
+    protected fun Collection<AbstractParty>.toPartyList(): List<Party> = map { it as Party }
 }

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ModifyBusinessIdentityFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ModifyBusinessIdentityFlow.kt
@@ -51,8 +51,8 @@ class ModifyBusinessIdentityFlow(
             it.state.data.identity.cordaIdentity
         }.filterNot {
             // remove modified member from signers only if it is not the flow initiator (since initiator must sign the transaction)
-            it == membership.state.data.identity.cordaIdentity && it != ourIdentity
-        }
+            it == membership.state.data.identity.cordaIdentity && it.name != ourIdentity.name
+        }.updated().toPartyList()
 
         // building transaction
         val outputMembership = membership.state.data.run {
@@ -66,7 +66,7 @@ class ModifyBusinessIdentityFlow(
         builder.verify(serviceHub)
 
         // collect signatures and finalise transaction
-        val observerSessions = (outputMembership.participants - ourIdentity).map { initiateFlow(it) }
+        val observerSessions = (outputMembership.participants.updated() - ourIdentity).map { initiateFlow(it) }
         val finalisedTransaction = collectSignaturesAndFinaliseTransaction(builder, observerSessions, signers)
 
         auditLogger.info("$ourIdentity successfully modified Business Identity of a member with $membership membership ID from " +

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ModifyParticipantsFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/ModifyParticipantsFlow.kt
@@ -40,7 +40,7 @@ class ModifyParticipantsFlow(
                 .addCommand(MembershipContract.Commands.ModifyParticipants(requiredSigners), requiredSigners)
         builder.verify(serviceHub)
 
-        val observers = membership.state.data.participants.toSet() + participants - ourIdentity
+        val observers = membership.state.data.participants.updated().toSet() + participants.updated() - ourIdentity
         val observerSessions = observers.map { initiateFlow(it) }
         collectSignaturesAndFinaliseTransaction(builder, observerSessions, signers)
 

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/OnboardMembershipFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/OnboardMembershipFlow.kt
@@ -58,7 +58,7 @@ class OnboardMembershipFlow(
         try {
             // fetch observers
             val authorisedMembers = bnService.getMembersAuthorisedToModifyMembership(networkId)
-            val observers = (authorisedMembers.map { it.state.data.identity.cordaIdentity } - ourIdentity).toSet()
+            val observers = (authorisedMembers.map { it.state.data.identity.cordaIdentity }.updated() - ourIdentity).toSet()
 
             // build transaction
             val membershipState = MembershipState(

--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/RequestMembershipFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/RequestMembershipFlow.kt
@@ -114,7 +114,7 @@ class RequestMembershipFlowResponder(private val session: FlowSession) : Members
         try {
             // fetch observers
             val authorisedMemberships = bnService.getMembersAuthorisedToModifyMembership(networkId)
-            val observers = (authorisedMemberships.map { it.state.data.identity.cordaIdentity } - ourIdentity).toSet()
+            val observers = (authorisedMemberships.map { it.state.data.identity.cordaIdentity }.updated() - ourIdentity).toSet()
 
             // build transaction
             val membershipState = MembershipState(

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/ActivateMembershipFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/ActivateMembershipFlowTest.kt
@@ -53,6 +53,19 @@ class ActivateMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthoris
     }
 
     @Test(timeout = 300_000)
+    fun `activate membership flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val membership = runRequestMembershipFlow(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        restartNodeWithRotateIdentityKey(regularMember)
+        runActivateMembershipFlow(restartedAuthorisedMember, membership.linearId)
+    }
+
+    @Test(timeout = 300_000)
     fun `activate membership flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val regularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/BNOAccessControlReportFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/BNOAccessControlReportFlowTest.kt
@@ -26,6 +26,26 @@ class BNOAccessControlReportFlowTest : MembershipManagementFlowTest(numberOfAuth
     }
 
     @Test(timeout = 300_000)
+    fun `bno access control flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val firstRegularMember = regularMembers.first()
+        val secondRegularMember = regularMembers.last()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        listOf(firstRegularMember, secondRegularMember).forEach { member ->
+            runRequestAndActivateMembershipFlows(member, authorisedMember, networkId)
+        }
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        listOf(firstRegularMember, secondRegularMember).forEach { member ->
+            restartNodeWithRotateIdentityKey(member)
+        }
+
+        runBNOAccessControlReportFlow(restartedAuthorisedMember, networkId)
+    }
+
+    @Test(timeout = 300_000)
     fun `bno access control flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val firstRegularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/CreateBusinessNetworkFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/CreateBusinessNetworkFlowTest.kt
@@ -69,6 +69,15 @@ class CreateBusinessNetworkFlowTest : MembershipManagementFlowTest(numberOfAutho
     }
 
     @Test(timeout = 300_000)
+    fun `create business network flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        runCreateBusinessNetworkFlow(authorisedMember)
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        runCreateBusinessNetworkFlow(restartedAuthorisedMember)
+    }
+
+    @Test(timeout = 300_000)
     fun `create business network flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val (membership, command) = runCreateBusinessNetworkFlow(authorisedMember, businessIdentity = DummyIdentity("dummy-identity")).run {

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/CreateGroupFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/CreateGroupFlowTest.kt
@@ -104,6 +104,20 @@ class CreateGroupFlowTest : MembershipManagementFlowTest(numberOfAuthorisedMembe
     }
 
     @Test(timeout = 300_000)
+    fun `create group should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = authorisedMembership.networkId
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        restartNodeWithRotateIdentityKey(regularMember)
+        runCreateGroupFlow(restartedAuthorisedMember, networkId, additionalParticipants = setOf(regularMembership.linearId))
+    }
+
+    @Test(timeout = 300_000)
     fun `create group flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val regularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/ModifyGroupFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/ModifyGroupFlowTest.kt
@@ -128,6 +128,22 @@ class ModifyGroupFlowTest : MembershipManagementFlowTest(numberOfAuthorisedMembe
     }
 
     @Test(timeout = 300_000)
+    fun `modify group flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val authorisedMembership = runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState
+        val networkId = authorisedMembership.networkId
+        val regularMembership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val group = runCreateGroupFlow(authorisedMember, networkId, additionalParticipants = setOf(regularMembership.linearId)).tx.outputStates.single() as GroupState
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        restartNodeWithRotateIdentityKey(regularMember)
+        runModifyGroupFlow(restartedAuthorisedMember, group.linearId, "default-group", setOf(authorisedMembership.linearId, regularMembership.linearId))
+    }
+
+    @Test(timeout = 300_000)
     fun `modify group flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val regularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/OnboardMembershipFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/OnboardMembershipFlowTest.kt
@@ -72,6 +72,17 @@ class OnboardMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthorise
     }
 
     @Test(timeout = 300_000)
+    fun `onboard membership flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        runOnboardMembershipFlow(restartedAuthorisedMember, networkId, regularMember.identity())
+    }
+
+    @Test(timeout = 300_000)
     fun `onboard membership flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val regularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RequestMembershipFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RequestMembershipFlowTest.kt
@@ -80,6 +80,17 @@ class RequestMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthorise
     }
 
     @Test(timeout = 300_000)
+    fun `request membership flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+
+        restartNodeWithRotateIdentityKey(authorisedMember)
+        runRequestMembershipFlow(regularMember, authorisedMember, networkId)
+    }
+
+    @Test(timeout = 300_000)
     fun `request membership flow happy path`() {
         val authorisedMember = authorisedMembers.first()
         val regularMember = regularMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RevokeMembershipFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/RevokeMembershipFlowTest.kt
@@ -59,6 +59,19 @@ class RevokeMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthorised
         assertFailsWith<InvalidBusinessNetworkStateException> { runRevokeMembershipFlow(authorisedMember, authorisedMembership.linearId) }
     }
 
+	@Test(timeout = 300_000)
+	fun `revoke membership flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        restartNodeWithRotateIdentityKey(regularMember)
+        runRevokeMembershipFlow(restartedAuthorisedMember, membership.linearId)
+	}
+
     @Test(timeout = 300_000)
     fun `revoke membership flow happy path`() {
         val authorisedMember = authorisedMembers.first()

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/SuspendMembershipFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/SuspendMembershipFlowTest.kt
@@ -60,6 +60,19 @@ class SuspendMembershipFlowTest : MembershipManagementFlowTest(numberOfAuthorise
         assertFailsWith<InvalidBusinessNetworkStateException> { runSuspendMembershipFlow(authorisedMember, authorisedMembership.linearId) }
     }
 
+	@Test(timeout = 300_000)
+	fun `suspend membership flow should work after certificate renewal`() {
+        val authorisedMember = authorisedMembers.first()
+        val regularMember = regularMembers.first()
+
+        val networkId = (runCreateBusinessNetworkFlow(authorisedMember).tx.outputStates.single() as MembershipState).networkId
+        val membership = runRequestAndActivateMembershipFlows(regularMember, authorisedMember, networkId).tx.outputStates.single() as MembershipState
+
+        val restartedAuthorisedMember = restartNodeWithRotateIdentityKey(authorisedMember)
+        restartNodeWithRotateIdentityKey(regularMember)
+        runSuspendMembershipFlow(restartedAuthorisedMember, membership.linearId)
+	}
+
     @Test(timeout = 300_000)
     fun `suspend membership flow happy path`() {
         val authorisedMember = authorisedMembers.first()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaGradlePluginsVersion=5.0.11
 cordaPlatformVersion=8
 cordaReleaseGroup=net.corda
 cordaUpdatesVersion=2.0
-cordaVersion=4.6-SNAPSHOT
+cordaVersion=4.7-HC01
 quasarVersion=0.7.13_r3
 quasarClassifier=
 junitVersion=4.12
@@ -19,4 +19,4 @@ slf4jVersion=1.7.26
 mavenResolverVersion=1.4.1
 jacksonVersion=2.9.7
 
-projectVersion=1.0-SNAPSHOT
+projectVersion=1.1-SNAPSHOT


### PR DESCRIPTION
## Description

This PR adapts existing Business Networks Extension (BNE) solution to the new Certificate renewal feature introduced in [ENT-5658](https://r3-cev.atlassian.net/browse/ENT-5658).

First we modify `BNService` to perform group participation checks based on X500 names and not full `Party` object.

We also introduce new method `Collection<AbstractParty>.updated()` method which iterates over each `AbstractParty` of the list, takes it's name (if it exists) and Identity Service returns `AbstractParty` object with the latest owning key and same X500 name. We adapt all membership management flow to use this method when fetching required signers and creating observer flow sessions.

*Note that we remove one contract check to adapt it to the new certificate renewal features. We will write proper contract upgrade code in the next PRs.*

In the end we add tests to ensure all membership management flows are compatible with certificate renewal.

## Test Plan

Ensure all existing and new tests pass.

Deploy nodes with new BNE Jar and check that CorDapp doesn't fail for the renewed certificates.