### PR TITLE
Complete PersistentMembershipState mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@ only know about those in their group).
 
 In a business network, there is at least one *authorised member*. This member has sufficient permissions to execute management operations over the network and its members.
 
+## Installation
+
+Add the `business-networks-contracts` dependency in your "contracts" (and states) cordapp module:
+
+```groovy
+dependencies {
+    //...
+    cordapp("net.corda.bn:business-networks-contracts:$corda_bn_extension_version")
+    //...
+}
+``` 
+
+... and the `business-networks-workflows` dependency in your "workflows" cordapp module:
+
+```groovy
+dependencies {
+    //...
+	cordapp("net.corda.bn:business-networks-workflows:$corda_bn_extension_version")
+    //...
+}
+```
+
+Remember to add both dependencies in your Cordform (i.e. `deployNodes`) task.
+
 ## Creating and managing a business network
 
 BNE provides a set of workflows that allows a user to start a business network, on-board members and assign them to membership lists or groups. The flows can also be used to update the information

--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
@@ -31,8 +31,8 @@ object MembershipStateSchemaV1 : MappedSchema(schemaFamily = MembershipState::cl
             @Column(name = "corda_identity", nullable = false)
             val cordaIdentity: Party,
             /** String representation of custom [BNIdentity] */
-            @Column(name = "business_identity", nullable = false)
-            val businessIdentity: String,
+            @Column(name = "business_identity")
+            val businessIdentity: String?,
             @Column(name = "network_id", nullable = false)
             val networkId: String,
             @Column(name = "status", nullable = false)

--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/schemas/MembershipStateSchemaV1.kt
@@ -1,11 +1,13 @@
 package net.corda.bn.schemas
 
+import net.corda.bn.states.BNIdentity
 import net.corda.bn.states.MembershipState
 import net.corda.bn.states.MembershipStatus
 import net.corda.core.identity.Party
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
 import net.corda.core.serialization.CordaSerializable
+import java.time.Instant
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Table
@@ -26,11 +28,20 @@ object MembershipStateSchemaV1 : MappedSchema(schemaFamily = MembershipState::cl
     @Entity
     @Table(name = "membership_state")
     class PersistentMembershipState(
-            @Column(name = "corda_identity")
+            @Column(name = "corda_identity", nullable = false)
             val cordaIdentity: Party,
-            @Column(name = "network_id")
+            /** String representation of custom [BNIdentity] */
+            @Column(name = "business_identity", nullable = false)
+            val businessIdentity: String,
+            @Column(name = "network_id", nullable = false)
             val networkId: String,
-            @Column(name = "status")
-            val status: MembershipStatus
+            @Column(name = "status", nullable = false)
+            val status: MembershipStatus,
+            @Column(name = "issuer_identity", nullable = false)
+            val issuer: Party,
+            @Column(name = "issued", nullable = false)
+            val issued: Instant,
+            @Column(name = "modified", nullable = false)
+            val modified: Instant
     ) : PersistentState()
 }

--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -39,8 +39,13 @@ data class MembershipState(
     override fun generateMappedObject(schema: MappedSchema) = when (schema) {
         is MembershipStateSchemaV1 -> MembershipStateSchemaV1.PersistentMembershipState(
                 cordaIdentity = identity.cordaIdentity,
+                businessIdentity = identity.businessIdentity.toString(),
                 networkId = networkId,
-                status = status
+                status = status,
+                issuer = issuer,
+                issued = issued,
+                modified = modified
+
         )
         else -> throw IllegalArgumentException("Unrecognised schema $schema")
     }

--- a/business-networks-contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
+++ b/business-networks-contracts/src/main/kotlin/net/corda/bn/states/MembershipState.kt
@@ -39,7 +39,7 @@ data class MembershipState(
     override fun generateMappedObject(schema: MappedSchema) = when (schema) {
         is MembershipStateSchemaV1 -> MembershipStateSchemaV1.PersistentMembershipState(
                 cordaIdentity = identity.cordaIdentity,
-                businessIdentity = identity.businessIdentity.toString(),
+                businessIdentity = identity.businessIdentity?.toString(),
                 networkId = networkId,
                 status = status,
                 issuer = issuer,

--- a/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-additional-fields.xml
+++ b/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-additional-fields.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3 Corda" id="complete_initial_membership_state_columns_and_constraints">
+        <addNotNullConstraint tableName="membership_state" columnName="corda_identity" columnDataType="varchar(255)"/>
+        <addNotNullConstraint tableName="membership_state" columnName="network_id" columnDataType="varchar(255)"/>
+        <addNotNullConstraint tableName="membership_state" columnName="status" columnDataType="integer"/>
+        <addColumn tableName="membership_state">
+            <column name="business_identity" type="varchar(64)" />
+            <column name="issuer_identity" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issued" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
+++ b/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
@@ -18,21 +18,4 @@
                        constraintName="PK_MembershipStateSchemaV1"
                        tableName="membership_state"/>
     </changeSet>
-    <changeSet author="R3 Corda" id="complete_initial_membership_state_columns_and_constraints">
-        <addNotNullConstraint tableName="membership_state" columnName="corda_identity" columnDataType="varchar(255)"/>
-        <addNotNullConstraint tableName="membership_state" columnName="network_id" columnDataType="varchar(255)"/>
-        <addNotNullConstraint tableName="membership_state" columnName="status" columnDataType="integer"/>
-        <addColumn tableName="membership_state">
-            <column name="business_identity" type="varchar(64)" />
-            <column name="issuer_identity" type="varchar(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="issued" type="TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
-            <column name="modified" type="TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
-        </addColumn>
-    </changeSet>
 </databaseChangeLog>

--- a/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
+++ b/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
@@ -23,9 +23,7 @@
         <addNotNullConstraint tableName="membership_state" columnName="network_id" columnDataType="varchar(255)"/>
         <addNotNullConstraint tableName="membership_state" columnName="status" columnDataType="integer"/>
         <addColumn tableName="membership_state">
-            <column name="business_identity" type="varchar(64)">
-                <constraints nullable="false"/>
-            </column>
+            <column name="business_identity" type="varchar(64)" />
             <column name="issuer_identity" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>

--- a/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
+++ b/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-init.xml
@@ -18,4 +18,23 @@
                        constraintName="PK_MembershipStateSchemaV1"
                        tableName="membership_state"/>
     </changeSet>
+    <changeSet author="R3 Corda" id="complete_initial_membership_state_columns_and_constraints">
+        <addNotNullConstraint tableName="membership_state" columnName="corda_identity" columnDataType="varchar(255)"/>
+        <addNotNullConstraint tableName="membership_state" columnName="network_id" columnDataType="varchar(255)"/>
+        <addNotNullConstraint tableName="membership_state" columnName="status" columnDataType="integer"/>
+        <addColumn tableName="membership_state">
+            <column name="business_identity" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issuer_identity" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issued" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-master.xml
+++ b/business-networks-contracts/src/main/resources/migration/membership-state-schema-v1.changelog-master.xml
@@ -3,4 +3,5 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <include relativeToChangelogFile="true" file="membership-state-schema-v1.changelog-init.xml"/>
+    <include relativeToChangelogFile="true" file="membership-state-schema-v1.changelog-additional-fields.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Updated `PersistentMembershipState` and with additional constraints and state member mappings:

- Added non-null constraints to `PersistentMembershipState`'s `cordaIdentity`, `networkId`, `status`
- Added `PersistentMembershipState` `issuer`, `issued` and `modified` to expose as query criteria
- Added nullable `PersistentMembershipState` `businessIdentity` based on the `BNIdentity?.toString()` implementation used,  to expose as query criteria
- Added liquibase changesets for the above

I state that this PR is in accordance with the [Developer's Certificate of Origin](https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).