### PR TITLE
CORDA-4081: add groupId to report

### DIFF
--- a/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/BNOAccessControlReportFlow.kt
+++ b/business-networks-workflows/src/main/kotlin/net/corda/bn/flows/BNOAccessControlReportFlow.kt
@@ -16,6 +16,7 @@ import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
 import java.io.File
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Data class for storing information about a members and groups available on the network.
@@ -34,7 +35,7 @@ data class AccessControlMember(
         val cordaIdentity: Party,
         val businessIdentity: BNIdentity? = null,
         val membershipStatus: MembershipStatus,
-        val groups: Set<String?>,
+        val groups: Set<UUID>,
 
         @JsonSerialize(using = RoleSerializer::class)
         val roles: Set<BNRole>
@@ -45,6 +46,7 @@ data class AccessControlMember(
  */
 @CordaSerializable
 data class GroupInfo(
+        val id: UUID,
         val name: String?,
         val participants: List<Party>
 )
@@ -78,7 +80,7 @@ class BNOAccessControlReportFlow(
 
         // collect all groups and their members
         val groupInfos = bnService.getAllBusinessNetworkGroups(networkId).map {
-            GroupInfo(it.state.data.name, it.state.data.participants)
+            GroupInfo(it.state.data.linearId.id, it.state.data.name, it.state.data.participants)
         }.toSet()
 
         // Compare the groups and their members with our participants and update the membership if needed
@@ -115,7 +117,7 @@ class BNOAccessControlReportFlow(
                 val participants = groupState.participants
                 member.cordaIdentity in participants
             }.map {
-                it.name
+                it.id
             }
 
             member.copy(groups = member.groups + groupsPresent)

--- a/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/BNOAccessControlReportFlowTest.kt
+++ b/business-networks-workflows/src/test/kotlin/net/corda/bn/flows/BNOAccessControlReportFlowTest.kt
@@ -59,9 +59,9 @@ class BNOAccessControlReportFlowTest : MembershipManagementFlowTest(numberOfAuth
         val networkId = UniqueIdentifier()
 
         runCreateBusinessNetworkFlow(authorisedMember, networkId = networkId)
-
+        val groupId = UniqueIdentifier()
         val membership = runRequestAndActivateMembershipFlows(firstRegularMember, authorisedMember, networkId.toString()).tx.outputStates.single() as MembershipState
-        runCreateGroupFlow(authorisedMember, networkId.toString(), UniqueIdentifier(), "my-group", setOf(membership.linearId))
+        runCreateGroupFlow(authorisedMember, networkId.toString(), groupId, "my-group", setOf(membership.linearId))
 
         runRequestMembershipFlow(secondRegularMember, authorisedMember, networkId.toString())
 
@@ -78,7 +78,7 @@ class BNOAccessControlReportFlowTest : MembershipManagementFlowTest(numberOfAuth
         }.single()
 
         assertEquals(MembershipStatus.ACTIVE, infoForFirstRegularMember.membershipStatus)
-        assertTrue("my-group" in infoForFirstRegularMember.groups)
+        assertTrue(groupId.id in infoForFirstRegularMember.groups)
 
         val infoForSecondRegularMember = accessControlReport.members.filter {
             it.cordaIdentity == secondRegularMember.info.legalIdentities[0]


### PR DESCRIPTION
Sample output:

`Flow completed with result: AccessControlReport(members=[AccessControlMember(cordaIdentity=O=Bank A, L=London, C=GB, businessIdentity=null, membershipStatus=ACTIVE, groups=[a2c7573d-3851-4604-9f14-aedf4e5a9165], roles=[net.corda.bn.states.BNORole@7083ac5d])], groups=[GroupInfo(id=a2c7573d-3851-4604-9f14-aedf4e5a9165, name=null, participants=[O=Bank A, L=London, C=GB])])`