### PR TITLE
ES-1193: Use correct artifact locations post Artifactory migration 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,16 @@ buildscript {
         log4j_version = constants.getProperty("log4jVersion")
         slf4j_version = constants.getProperty("slf4jVersion")
         corda_platform_version = constants.getProperty("platformVersion")
+        publicArtifactURL='https://download.corda.net/maven'
     }
 
     repositories {
         mavenLocal()
         mavenCentral()
         jcenter()
-        maven { url "$artifactoryContextUrl/corda" }
-        maven { url "$artifactoryContextUrl/corda-releases" }
-        maven { url "$artifactoryContextUrl/corda-dev" }
+        maven { url "$publicArtifactURL/corda-dependencies" }
+        maven { url "$publicArtifactURL/corda-releases" }
+        maven { url "$publicArtifactURL/corda-dev" }
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
     }
 
@@ -75,9 +76,9 @@ allprojects {
         jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
-        maven { url "$artifactoryContextUrl/corda" }
-        maven { url "$artifactoryContextUrl/corda-releases" }
-        maven { url "$artifactoryContextUrl/corda-dev" }
+        maven { url "$publicArtifactURL/corda-dependencies" }
+        maven { url "$publicArtifactURL/corda-releases" }
+        maven { url "$publicArtifactURL/corda-dev" }
 
         // Required to resolve dependencies for corda-node-driver 4.1+
         maven { url "https://repo.gradle.org/gradle/libs-releases-local" }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         log4j_version = constants.getProperty("log4jVersion")
         slf4j_version = constants.getProperty("slf4jVersion")
         corda_platform_version = constants.getProperty("platformVersion")
-        publicArtifactURL='https://download.corda.net/maven'
+        publicArtifactURL=constants.getProperty('publicArtifactLocation')
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-Xmx1024m
 
 artifactoryContextUrl=https://software.r3.com/artifactory
+publicArtifactLocation=https://download.corda.net/maven
 
 # Dependency versions
 cordaGradlePluginsVersion=5.0.11


### PR DESCRIPTION
**Description:**
The PR Updates the repository locations in `build.gradle` to reference our public mirror, as the previously listed Artifactory locations are no longer available.  

Note `corda` updated to `corda-dependencies` here as corda is a `virtual repo`, i.e an aggregation of several repositories. In this case this aggregation is made up of `corda-releases` and `corda-dependencies ,` this concept of a virtual repository is Artifactory specific and does not exist in the public mirror therefore the exact repository must be specified.